### PR TITLE
Remaining AgendaListScreen UI (FAB, Logout Button, and ListItem.)

### DIFF
--- a/app/src/main/kotlin/com/gavinferiancek/tasky/MainActivity.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/MainActivity.kt
@@ -195,6 +195,27 @@ fun NavGraphBuilder.addAgendaScreen(
         AgendaScreen(
             state = viewModel.state,
             events = viewModel::onTriggerEvent,
+            onLogout = onLogout,
+            onNavigateToLogin = {
+                navController.navigate(Screens.Login.route) {
+                    popUpTo(Screens.AgendaList.route) { inclusive = true }
+                }
+            },
+            onNavigateToEventDetail = { navOptions ->
+                navController.navigate(
+                    "${Screens.EventDetail.route}/${navOptions.id}/${navOptions.isEditing}"
+                )
+            },
+            onNavigateToTaskDetail = { navOptions ->
+                navController.navigate(
+                    "${Screens.TaskDetail.route}/${navOptions.id}/${navOptions.isEditing}"
+                )
+            },
+            onNavigateToReminderDetail = { navOptions ->
+                navController.navigate(
+                    "${Screens.ReminderDetail.route}/${navOptions.id}/${navOptions.isEditing}"
+                )
+            },
         )
     }
 }

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/domain/NavigationOptions.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/domain/NavigationOptions.kt
@@ -1,0 +1,6 @@
+package com.gavinferiancek.tasky.agenda.domain
+
+data class NavigationOptions(
+    val id: String?,
+    val isEditing: Boolean,
+)

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaHeader.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaHeader.kt
@@ -25,15 +25,19 @@ import java.time.LocalDate
 /**
  * Composable that displays a header for the AgendaScreen.
  * @param modifier Modifier applied to [Row] that encapsulates AgendaHeader.
+ * @param name User name to be displayed.
  * @param initialDate Starting date that is used as a basis for the [TextButton]'s text as well
  * as the default selected date for the [datepicker].
  * @param onSelectDate Lambda to pass [LocalDate] selected in [datepicker] to parent Composable.
+ * @param onLogout Lambda  for [LogoutButton]'s Logout Action
  */
 @Composable
 fun AgendaHeader(
     modifier: Modifier = Modifier,
+    name: String,
     initialDate: LocalDate,
     onSelectDate: (LocalDate) -> Unit,
+    onLogout: () -> Unit,
 ) {
     val spacing = LocalSpacing.current
     val dialogState = rememberMaterialDialogState()
@@ -62,6 +66,10 @@ fun AgendaHeader(
                 tint = MaterialTheme.colors.onPrimary,
             )
         }
+        LogoutButton(
+            name = name,
+            onLogout = { onLogout() },
+        )
     }
     MaterialDialog(
         dialogState = dialogState,

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaList.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaList.kt
@@ -24,7 +24,7 @@ import java.time.format.DateTimeFormatter
  * @param modifier Modifier applied to LazyColumn.
  * @param pastItems [List]<[AgendaItem]> that contains a startTime before the current time.
  * @param futureItems [List]<[AgendaItem]> that contains a startTime after the current time.
- * @param onToggleIsDone Lambda to pass [Task] back to VM after toggling the isDone value.
+ * @param setIsDone Lambda to pass [Task] back to VM after toggling the isDone value.
  * @param onDelete Lambda to pass AgendaItem back to VM after clicking on it's Delete action.
  * @param onNavigateToEventDetail Lambda used to navigate to the Event detail screen with supplied NavigationOptions.
  * @param onNavigateToTaskDetail Lambda used to navigate to the Task detail screen with supplied NavigationOptions.
@@ -37,7 +37,7 @@ fun AgendaList(
     modifier: Modifier = Modifier,
     pastItems: List<AgendaItem>,
     futureItems: List<AgendaItem>,
-    onToggleIsDone: (Task) -> Unit,
+    setIsDone: (Task) -> Unit,
     onDelete: (AgendaItem) -> Unit,
     onNavigateToEventDetail: (NavigationOptions) -> Unit,
     onNavigateToTaskDetail: (NavigationOptions) -> Unit,
@@ -64,8 +64,8 @@ fun AgendaList(
                                 .animateItemPlacement(),
                             item = item,
                             formatter = dateFormatter,
-                            onToggleIsDone = { task ->
-                                onToggleIsDone(task)
+                            setIsDone = { task ->
+                                setIsDone(task)
                             },
                             onNavigateToEventDetail = onNavigateToEventDetail,
                             onNavigateToTaskDetail = onNavigateToTaskDetail,
@@ -95,8 +95,8 @@ fun AgendaList(
                                 .animateItemPlacement(),
                             item = item,
                             formatter = dateFormatter,
-                            onToggleIsDone = { task ->
-                                onToggleIsDone(task)
+                            setIsDone = { task ->
+                                setIsDone(task)
                             },
                             onNavigateToEventDetail = onNavigateToEventDetail,
                             onNavigateToTaskDetail = onNavigateToTaskDetail,

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaList.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaList.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import com.gavinferiancek.tasky.agenda.domain.NavigationOptions
 import com.gavinferiancek.tasky.agenda.domain.model.AgendaItem
+import com.gavinferiancek.tasky.agenda.domain.model.Task
+import com.gavinferiancek.tasky.agenda.presentation.components.list.item.AgendaListItem
 import com.gavinferiancek.tasky.core.presentation.theme.LocalSpacing
 import java.time.format.DateTimeFormatter
 
@@ -22,6 +24,12 @@ import java.time.format.DateTimeFormatter
  * @param modifier Modifier applied to LazyColumn.
  * @param pastItems [List]<[AgendaItem]> that contains a startTime before the current time.
  * @param futureItems [List]<[AgendaItem]> that contains a startTime after the current time.
+ * @param onToggleIsDone Lambda to pass [Task] back to VM after toggling the isDone value.
+ * @param onDelete Lambda to pass AgendaItem back to VM after clicking on it's Delete action.
+ * @param onNavigateToEventDetail Lambda used to navigate to the Event detail screen with supplied NavigationOptions.
+ * @param onNavigateToTaskDetail Lambda used to navigate to the Task detail screen with supplied NavigationOptions.
+ * @param onNavigateToReminderDetail Lambda used to navigate to the Reminder detail screen with supplied NavigationOptions.
+
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -29,6 +37,11 @@ fun AgendaList(
     modifier: Modifier = Modifier,
     pastItems: List<AgendaItem>,
     futureItems: List<AgendaItem>,
+    onToggleIsDone: (Task) -> Unit,
+    onDelete: (AgendaItem) -> Unit,
+    onNavigateToEventDetail: (NavigationOptions) -> Unit,
+    onNavigateToTaskDetail: (NavigationOptions) -> Unit,
+    onNavigateToReminderDetail: (NavigationOptions) -> Unit,
 ) {
     val spacing = LocalSpacing.current
     val hasData = remember(pastItems, futureItems) {
@@ -45,14 +58,23 @@ fun AgendaList(
                         items = pastItems,
                         key = { it.id }
                     ) { item ->
-                        //TODO Replace Text with AgendaItem Composable
-                        Text(text = remember(item.startTime) {
-                            item.startTime.format(
-                                dateFormatter
-                            )
-                        })
+                        AgendaListItem(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItemPlacement(),
+                            item = item,
+                            formatter = dateFormatter,
+                            onToggleIsDone = { task ->
+                                onToggleIsDone(task)
+                            },
+                            onNavigateToEventDetail = onNavigateToEventDetail,
+                            onNavigateToTaskDetail = onNavigateToTaskDetail,
+                            onNavigateToReminderDetail = onNavigateToReminderDetail,
+                            onDelete = { onDelete(item) },
+                        )
                         Spacer(modifier = Modifier.height(spacing.small))
                     }
+
                     item {
                         TimeNeedle(
                             modifier = Modifier
@@ -62,16 +84,25 @@ fun AgendaList(
                         )
                         Spacer(modifier = Modifier.height(spacing.small))
                     }
+
                     items(
                         items = futureItems,
                         key = { it.id }
                     ) { item ->
-                        //TODO Replace Text with AgendaItem Composable
-                        Text(text = remember(item.startTime) {
-                            item.startTime.format(
-                                dateFormatter
-                            )
-                        })
+                        AgendaListItem(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItemPlacement(),
+                            item = item,
+                            formatter = dateFormatter,
+                            onToggleIsDone = { task ->
+                                onToggleIsDone(task)
+                            },
+                            onNavigateToEventDetail = onNavigateToEventDetail,
+                            onNavigateToTaskDetail = onNavigateToTaskDetail,
+                            onNavigateToReminderDetail = onNavigateToReminderDetail,
+                            onDelete = { onDelete(item) },
+                        )
                         Spacer(modifier = Modifier.height(spacing.small))
                     }
                 }

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaListFab.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaListFab.kt
@@ -4,8 +4,10 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import com.gavinferiancek.tasky.R
 import com.gavinferiancek.tasky.agenda.domain.NavigationOptions
@@ -23,19 +25,19 @@ fun AgendaListFab(
     onNavigateToTaskDetail: (NavigationOptions) -> Unit,
     onNavigateToReminderDetail: (NavigationOptions) -> Unit,
 ) {
-    val isExpanded = remember { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
     FloatingActionButton(
-        onClick = { isExpanded.value = true },
+        onClick = { isExpanded = true },
         shape = MaterialTheme.shapes.medium,
         backgroundColor = MaterialTheme.colors.primary,
     ) {
         DropdownMenu(
-            expanded = isExpanded.value,
-            onDismissRequest = { isExpanded.value = false }
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false }
         ) {
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onNavigateToEventDetail(
                         NavigationOptions(
                             id = null,
@@ -47,7 +49,7 @@ fun AgendaListFab(
             )
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onNavigateToTaskDetail(
                         NavigationOptions(
                             id = null,
@@ -59,7 +61,7 @@ fun AgendaListFab(
             )
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onNavigateToReminderDetail(
                         NavigationOptions(
                             id = null,

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaListFab.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/AgendaListFab.kt
@@ -1,0 +1,78 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list
+
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.agenda.domain.NavigationOptions
+
+/**
+ * FAB Composable displayed on the AgendaListScreen
+ * @param onNavigateToEventDetail Lambda that navigates with the provided id, and edit state.
+ * @param onNavigateToTaskDetail Lambda that navigates with the provided id, and edit state.
+ * @param onNavigateToReminderDetail Lambda that navigates with the provided id, and edit state.
+ * (Note: FAB is used to create new items, so the id is always null and isEditing is always true.)
+ */
+@Composable
+fun AgendaListFab(
+    onNavigateToEventDetail: (NavigationOptions) -> Unit,
+    onNavigateToTaskDetail: (NavigationOptions) -> Unit,
+    onNavigateToReminderDetail: (NavigationOptions) -> Unit,
+) {
+    val isExpanded = remember { mutableStateOf(false) }
+    FloatingActionButton(
+        onClick = { isExpanded.value = true },
+        shape = MaterialTheme.shapes.medium,
+        backgroundColor = MaterialTheme.colors.primary,
+    ) {
+        DropdownMenu(
+            expanded = isExpanded.value,
+            onDismissRequest = { isExpanded.value = false }
+        ) {
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onNavigateToEventDetail(
+                        NavigationOptions(
+                            id = null,
+                            isEditing = true,
+                        )
+                    )
+                },
+                content = { Text(text = stringResource(R.string.action_event)) }
+            )
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onNavigateToTaskDetail(
+                        NavigationOptions(
+                            id = null,
+                            isEditing = true,
+                        )
+                    )
+                },
+                content = { Text(text = stringResource(R.string.action_task)) }
+            )
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onNavigateToReminderDetail(
+                        NavigationOptions(
+                            id = null,
+                            isEditing = true,
+                        )
+                    )
+                },
+                content = { Text(text = stringResource(R.string.action_reminder)) }
+            )
+        }
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = stringResource(id = R.string.agenda_list_fab_content_description)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/LogoutButton.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/LogoutButton.kt
@@ -1,0 +1,54 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.core.presentation.theme.LightBlue
+import com.gavinferiancek.tasky.core.presentation.theme.LocalSpacing
+import com.gavinferiancek.tasky.core.presentation.theme.muted
+
+/**
+ * [IconButton] Composable that handles the logout action.
+ * @param name Name to be displayed on the button. (Ideally user initials)
+ * @param onLogout Action to be performed when clicking the Logout DropDownMenuItem.
+ */
+@Composable
+fun LogoutButton(
+    name: String,
+    onLogout: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val isExpanded = remember { mutableStateOf(false) }
+
+    IconButton(
+        modifier = androidx.compose.ui.Modifier.padding(spacing.small),
+        onClick = { isExpanded.value = true }
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_baseline_circle_48),
+            tint = LightBlue,
+            contentDescription = null,
+        )
+        Text(
+            text = name,
+            color = MaterialTheme.colors.muted
+        )
+        DropdownMenu(
+            expanded = isExpanded.value,
+            onDismissRequest = { isExpanded.value = false }
+        ) {
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onLogout()
+                },
+                content = { Text(text = stringResource(id = R.string.action_logout)) },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/LogoutButton.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/LogoutButton.kt
@@ -3,8 +3,10 @@ package com.gavinferiancek.tasky.agenda.presentation.components.list
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.gavinferiancek.tasky.R
@@ -23,11 +25,11 @@ fun LogoutButton(
     onLogout: () -> Unit,
 ) {
     val spacing = LocalSpacing.current
-    val isExpanded = remember { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     IconButton(
         modifier = androidx.compose.ui.Modifier.padding(spacing.small),
-        onClick = { isExpanded.value = true }
+        onClick = { isExpanded = true }
     ) {
         Icon(
             painter = painterResource(id = R.drawable.ic_baseline_circle_48),
@@ -39,12 +41,12 @@ fun LogoutButton(
             color = MaterialTheme.colors.muted
         )
         DropdownMenu(
-            expanded = isExpanded.value,
-            onDismissRequest = { isExpanded.value = false }
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false }
         ) {
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onLogout()
                 },
                 content = { Text(text = stringResource(id = R.string.action_logout)) },

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListCard.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListCard.kt
@@ -18,7 +18,7 @@ import com.gavinferiancek.tasky.core.presentation.theme.LocalSpacing
  * @param backgroundColor [Color] to apply to [Card] backgroundColor param.
  * @param contentColor [Color] to apply to content inside the [Card] composable.
  * @param description [String] used in [Card] body
- * @param timestamp [String] displayed at bottom of card.
+ * @param formattedTime [String] displayed at bottom of card.
  * @param title Slot for Composable displayed in the top row of the [Card]
  * @param onOpen Lambda for [CardMenuButton]'s Open action as well as the [Card]'s onClick action.
  * @param onEdit Lambda for [CardMenuButton]'s Edit action
@@ -30,7 +30,7 @@ fun AgendaListCard(
     backgroundColor: Color,
     contentColor: Color,
     description: String,
-    timestamp: String,
+    formattedTime: String,
     title: @Composable () -> Unit,
     onOpen: () -> Unit,
     onEdit: () -> Unit,
@@ -75,7 +75,7 @@ fun AgendaListCard(
 
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                text = timestamp,
+                text = formattedTime,
                 style = MaterialTheme.typography.body1,
                 textAlign = TextAlign.End,
             )

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListCard.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListCard.kt
@@ -1,0 +1,84 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list.item
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import com.gavinferiancek.tasky.core.presentation.theme.LocalSpacing
+
+/**
+ * Composable that contains the base structure and styling logic for our AgendaListItems.
+ * @param modifier [Modifier] applied to the [Card] Composable.
+ * @param backgroundColor [Color] to apply to [Card] backgroundColor param.
+ * @param contentColor [Color] to apply to content inside the [Card] composable.
+ * @param description [String] used in [Card] body
+ * @param timestamp [String] displayed at bottom of card.
+ * @param title Slot for Composable displayed in the top row of the [Card]
+ * @param onOpen Lambda for [CardMenuButton]'s Open action as well as the [Card]'s onClick action.
+ * @param onEdit Lambda for [CardMenuButton]'s Edit action
+ * @param onDelete Lambda for [CardMenuButton]'s Delete action
+ */
+@Composable
+fun AgendaListCard(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color,
+    contentColor: Color,
+    description: String,
+    timestamp: String,
+    title: @Composable () -> Unit,
+    onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+
+    Card(
+        modifier = modifier
+            .clickable { onOpen() },
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+    ) {
+        Column(
+            modifier = Modifier.padding(
+                top = spacing.small,
+                start = spacing.small,
+                end = spacing.medium,
+                bottom = spacing.small,
+            )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                title()
+                CardMenuButton(
+                    onOpen = onOpen,
+                    onEdit = onEdit,
+                    onDelete = onDelete
+                )
+            }
+            Text(
+                modifier = Modifier
+                    .padding(start = spacing.extraLarge),
+                text = description,
+                style = MaterialTheme.typography.body1,
+            )
+            Spacer(modifier = Modifier.height(spacing.medium))
+
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = timestamp,
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.End,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListItem.kt
@@ -15,7 +15,7 @@ import java.time.format.DateTimeFormatter
  * @param modifier Modifier passed to [EventItem]/[TaskItem]/[ReminderItem]
  * @param item [AgendaItem] containing the data for the item to be composed.
  * @param formatter [DateTimeFormatter] used to format startTime and endTimes.
- * @param onToggleIsDone Lambda to pass Task back to VM with a toggled isDone state.
+ * @param setIsDone Lambda to pass Task back to VM with a toggled isDone state.
  * @param onNavigateToEventDetail Lambda used to navigate to the Event detail screen with supplied NavigationOptions.
  * @param onNavigateToTaskDetail Lambda used to navigate to the Task detail screen with supplied NavigationOptions.
  * @param onNavigateToReminderDetail Lambda used to navigate to the Reminder detail screen with supplied NavigationOptions.
@@ -26,7 +26,7 @@ fun AgendaListItem(
     modifier: Modifier = Modifier,
     item: AgendaItem,
     formatter: DateTimeFormatter,
-    onToggleIsDone: (Task) -> Unit,
+    setIsDone: (Task) -> Unit,
     onNavigateToEventDetail: (NavigationOptions) -> Unit,
     onNavigateToTaskDetail: (NavigationOptions) -> Unit,
     onNavigateToReminderDetail: (NavigationOptions) -> Unit,
@@ -67,7 +67,7 @@ fun AgendaListItem(
                 description = item.description,
                 timestamp = remember(item.startTime) { item.startTime.format(formatter) },
                 isDone = item.isDone,
-                onToggleIsDone = { onToggleIsDone(item.copy(isDone = !item.isDone)) },
+                setIsDone = { setIsDone(item.copy(isDone = !item.isDone)) },
                 onOpen = {
                     onNavigateToTaskDetail(
                         NavigationOptions(

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/AgendaListItem.kt
@@ -1,0 +1,116 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list.item
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import com.gavinferiancek.tasky.agenda.domain.NavigationOptions
+import com.gavinferiancek.tasky.agenda.domain.model.AgendaItem
+import com.gavinferiancek.tasky.agenda.domain.model.Event
+import com.gavinferiancek.tasky.agenda.domain.model.Reminder
+import com.gavinferiancek.tasky.agenda.domain.model.Task
+import java.time.format.DateTimeFormatter
+
+/**
+ * Wrapper Composable that takes in an [AgendaItem] and composes the correct Item for that AgendaItem type.
+ * @param modifier Modifier passed to [EventItem]/[TaskItem]/[ReminderItem]
+ * @param item [AgendaItem] containing the data for the item to be composed.
+ * @param formatter [DateTimeFormatter] used to format startTime and endTimes.
+ * @param onToggleIsDone Lambda to pass Task back to VM with a toggled isDone state.
+ * @param onNavigateToEventDetail Lambda used to navigate to the Event detail screen with supplied NavigationOptions.
+ * @param onNavigateToTaskDetail Lambda used to navigate to the Task detail screen with supplied NavigationOptions.
+ * @param onNavigateToReminderDetail Lambda used to navigate to the Reminder detail screen with supplied NavigationOptions.
+ * @param onDelete Lambda used for the [AgendaListCard]'s Delete DropDownMenuItem action.
+ */
+@Composable
+fun AgendaListItem(
+    modifier: Modifier = Modifier,
+    item: AgendaItem,
+    formatter: DateTimeFormatter,
+    onToggleIsDone: (Task) -> Unit,
+    onNavigateToEventDetail: (NavigationOptions) -> Unit,
+    onNavigateToTaskDetail: (NavigationOptions) -> Unit,
+    onNavigateToReminderDetail: (NavigationOptions) -> Unit,
+    onDelete: () -> Unit,
+) {
+    when (item) {
+        is Event -> {
+            EventItem(
+                modifier = modifier,
+                title = item.title,
+                description = item.description,
+                timestamp = remember(item.startTime, item.endTime) {
+                    "${item.startTime.format(formatter)} - ${item.endTime.format(formatter)}"
+                },
+                onOpen = {
+                    onNavigateToEventDetail(
+                        NavigationOptions(
+                            id = item.id,
+                            isEditing = false,
+                        )
+                    )
+                },
+                onEdit = {
+                    onNavigateToEventDetail(
+                        NavigationOptions(
+                            id = item.id,
+                            isEditing = true,
+                        )
+                    )
+                },
+                onDelete = { onDelete() },
+            )
+        }
+        is Task -> {
+            TaskItem(
+                modifier = modifier,
+                title = item.title,
+                description = item.description,
+                timestamp = remember(item.startTime) { item.startTime.format(formatter) },
+                isDone = item.isDone,
+                onToggleIsDone = { onToggleIsDone(item.copy(isDone = !item.isDone)) },
+                onOpen = {
+                    onNavigateToTaskDetail(
+                        NavigationOptions(
+                            id = item.id,
+                            isEditing = false,
+                        )
+                    )
+                },
+                onEdit = {
+                    onNavigateToTaskDetail(
+                        NavigationOptions(
+                            id = item.id,
+                            isEditing = true,
+                        )
+                    )
+                },
+                onDelete = { onDelete() },
+            )
+        }
+        is Reminder -> {
+            ReminderItem(
+                modifier = modifier,
+                title = item.title,
+                description = item.description,
+                timestamp = remember(item.startTime) { item.startTime.format(formatter) },
+                onOpen = {
+                    onNavigateToReminderDetail(
+                        NavigationOptions(
+                            id = item.id,
+                            isEditing = false,
+                        )
+                    )
+                },
+                onEdit = {
+                    onNavigateToReminderDetail(
+                        NavigationOptions(
+                            id = item.id,
+                            isEditing = true,
+                        )
+                    )
+                },
+                onDelete = { onDelete() },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/CardMenuButton.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/CardMenuButton.kt
@@ -1,0 +1,73 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list.item
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.core.presentation.theme.LightBlue
+
+/**
+ * Composable that responds to button clicks with a popup of context actions.
+ * @param onOpen Action to be performed when clicking on the Open DropDownMenuItem.
+ * @param onEdit Action to be performed when clicking on the Edit DropDownMenuItem.
+ * @param onDelete Action to be performed when clicking on the Delete DropDownMenuItem.
+ */
+@Composable
+fun CardMenuButton(
+    onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val isExpanded = remember { mutableStateOf(false) }
+    IconButton(onClick = { isExpanded.value = true }) {
+        Icon(
+            modifier = Modifier
+                .clip(CircleShape),
+            painter = painterResource(id = R.drawable.ic_baseline_more_horiz_24),
+            contentDescription = stringResource(id = R.string.list_item_menu_content_description),
+        )
+        DropdownMenu(
+            expanded = isExpanded.value,
+            onDismissRequest = {
+                isExpanded.value = false
+            }
+        ) {
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onOpen()
+                },
+                content = { Text(stringResource(id = R.string.action_open)) },
+            )
+            Divider(
+                thickness = 1.dp,
+                color = LightBlue
+            )
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onEdit()
+                },
+                content = { Text(text = stringResource(id = R.string.action_edit)) },
+            )
+            Divider(
+                thickness = 1.dp,
+                color = LightBlue
+            )
+            DropdownMenuItem(
+                onClick = {
+                    isExpanded.value = false
+                    onDelete()
+                },
+                content = { Text(text = stringResource(id = R.string.action_delete)) },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/CardMenuButton.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/CardMenuButton.kt
@@ -3,8 +3,10 @@ package com.gavinferiancek.tasky.agenda.presentation.components.list.item
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
@@ -25,8 +27,8 @@ fun CardMenuButton(
     onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    val isExpanded = remember { mutableStateOf(false) }
-    IconButton(onClick = { isExpanded.value = true }) {
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    IconButton(onClick = { isExpanded = true }) {
         Icon(
             modifier = Modifier
                 .clip(CircleShape),
@@ -34,14 +36,14 @@ fun CardMenuButton(
             contentDescription = stringResource(id = R.string.list_item_menu_content_description),
         )
         DropdownMenu(
-            expanded = isExpanded.value,
+            expanded = isExpanded,
             onDismissRequest = {
-                isExpanded.value = false
+                isExpanded = false
             }
         ) {
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onOpen()
                 },
                 content = { Text(stringResource(id = R.string.action_open)) },
@@ -52,7 +54,7 @@ fun CardMenuButton(
             )
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onEdit()
                 },
                 content = { Text(text = stringResource(id = R.string.action_edit)) },
@@ -63,7 +65,7 @@ fun CardMenuButton(
             )
             DropdownMenuItem(
                 onClick = {
-                    isExpanded.value = false
+                    isExpanded = false
                     onDelete()
                 },
                 content = { Text(text = stringResource(id = R.string.action_delete)) },

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/EventItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/EventItem.kt
@@ -37,7 +37,7 @@ fun EventItem(
         backgroundColor = LimeGreen,
         contentColor = MaterialTheme.colors.onSurface,
         description = description,
-        timestamp = timestamp,
+        formattedTime = timestamp,
         title = {
             Row(
                 modifier = Modifier.fillMaxWidth(0.9f),

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/EventItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/EventItem.kt
@@ -1,0 +1,67 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list.item
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.core.presentation.theme.LimeGreen
+
+/** Composable used to display Event Data
+ * @param modifier [Modifier] passed to [AgendaListCard]
+ * @param title [String] used in [AgendaListCard]'s title slot
+ * @param description [String] used in [AgendaListCard]'s body slot.
+ * @param timestamp [String] used in [AgendaListCard]'s footer slot.
+ * @param onOpen Lambda used for the [AgendaListCard]'s Open action and Card click.
+ * @param onEdit Lambda used for the [AgendaListCard]'s Edit action.
+ * @param onDelete Lambda used for the [AgendaListCard]'s Delete action.
+ */
+@Composable
+fun EventItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+    timestamp: String,
+    onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    AgendaListCard(
+        modifier = modifier,
+        backgroundColor = LimeGreen,
+        contentColor = MaterialTheme.colors.onSurface,
+        description = description,
+        timestamp = timestamp,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(0.9f),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // IconButton is used for consistency in padding/alignment with TaskItem
+                IconButton(
+                    enabled = false,
+                    onClick = {},
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_outline_circle_24),
+                        tint = MaterialTheme.colors.onSurface,
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.h2,
+                )
+            }
+        },
+        onOpen = { onOpen() },
+        onEdit = { onEdit() },
+        onDelete = { onDelete() },
+    )
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/ReminderItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/ReminderItem.kt
@@ -37,7 +37,7 @@ fun ReminderItem(
         backgroundColor = LightGray,
         contentColor = MaterialTheme.colors.onSurface,
         description = description,
-        timestamp = timestamp,
+        formattedTime = timestamp,
         title = {
             Row(
                 modifier = Modifier.fillMaxWidth(0.9f),

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/ReminderItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/ReminderItem.kt
@@ -1,0 +1,67 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list.item
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.core.presentation.theme.LightGray
+
+/** Composable used to display Reminder Data
+ * @param modifier [Modifier] passed to [AgendaListCard]
+ * @param title [String] used in [AgendaListCard]'s title slot
+ * @param description [String] used in [AgendaListCard]'s body slot.
+ * @param timestamp [String] used in [AgendaListCard]'s footer slot.
+ * @param onOpen Lambda used for the [CardMenuButton]'s Open action and Card click.
+ * @param onEdit Lambda used for the [CardMenuButton]'s Edit action.
+ * @param onDelete Lambda used for the [CardMenuButton]'s Delete action.
+ */
+@Composable
+fun ReminderItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+    timestamp: String,
+    onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    AgendaListCard(
+        modifier = modifier,
+        backgroundColor = LightGray,
+        contentColor = MaterialTheme.colors.onSurface,
+        description = description,
+        timestamp = timestamp,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(0.9f),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Button is used for consistency for padding/alignment with TaskItem
+                IconButton(
+                    enabled = false,
+                    onClick = {},
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_outline_circle_24),
+                        tint = MaterialTheme.colors.onSurface,
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.h2,
+                )
+            }
+        },
+        onOpen = { onOpen() },
+        onEdit = { onEdit() },
+        onDelete = { onDelete() },
+    )
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/TaskItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/TaskItem.kt
@@ -1,0 +1,81 @@
+package com.gavinferiancek.tasky.agenda.presentation.components.list.item
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.core.presentation.theme.DarkGreen
+
+/** Composable used to display Event Data
+ * @param modifier [Modifier] passed to [AgendaListCard]
+ * @param title [String] used in [AgendaListCard]'s title slot
+ * @param description [String] used in [AgendaListCard]'s body slot.
+ * @param timestamp [String] used in [AgendaListCard]'s footer slot.
+ * @param isDone [Boolean] used to style title based on value.
+ * @param onToggleIsDone Lambda trigged when clicking on Circle [Box] in title row.
+ * @param onOpen Lambda used for the [CardMenuButton]'s Open action and Card click.
+ * @param onEdit Lambda used for the [CardMenuButton]'s Edit action.
+ * @param onDelete Lambda used for the [CardMenuButton]'s Delete action.
+ */
+@Composable
+fun TaskItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    description: String,
+    timestamp: String,
+    isDone: Boolean,
+    onToggleIsDone: () -> Unit,
+    onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val iconResId = remember(isDone) {
+        if (isDone) R.drawable.ic_outline_check_circle_24
+        else R.drawable.ic_outline_circle_24
+    }
+    val textDecoration = remember(isDone) {
+        if (isDone) TextDecoration.LineThrough
+        else TextDecoration.None
+    }
+
+    AgendaListCard(
+        modifier = modifier,
+        backgroundColor = DarkGreen,
+        contentColor = MaterialTheme.colors.onPrimary,
+        description = description,
+        timestamp = timestamp,
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(0.9f),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { onToggleIsDone() }) {
+                    Icon(
+                        painter = painterResource(id = iconResId),
+                        tint = MaterialTheme.colors.onPrimary,
+                        contentDescription = stringResource(id = R.string.is_done_toggle_content_description),
+                    )
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.h2,
+                    textDecoration = textDecoration,
+                )
+            }
+        },
+        onOpen = { onOpen() },
+        onEdit = { onEdit() },
+        onDelete = { onDelete() },
+    )
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/TaskItem.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/components/list/item/TaskItem.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -23,7 +22,7 @@ import com.gavinferiancek.tasky.core.presentation.theme.DarkGreen
  * @param description [String] used in [AgendaListCard]'s body slot.
  * @param timestamp [String] used in [AgendaListCard]'s footer slot.
  * @param isDone [Boolean] used to style title based on value.
- * @param onToggleIsDone Lambda trigged when clicking on Circle [Box] in title row.
+ * @param setIsDone Lambda trigged when clicking on Circle [Box] in title row.
  * @param onOpen Lambda used for the [CardMenuButton]'s Open action and Card click.
  * @param onEdit Lambda used for the [CardMenuButton]'s Edit action.
  * @param onDelete Lambda used for the [CardMenuButton]'s Delete action.
@@ -35,34 +34,25 @@ fun TaskItem(
     description: String,
     timestamp: String,
     isDone: Boolean,
-    onToggleIsDone: () -> Unit,
+    setIsDone: () -> Unit,
     onOpen: () -> Unit,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    val iconResId = remember(isDone) {
-        if (isDone) R.drawable.ic_outline_check_circle_24
-        else R.drawable.ic_outline_circle_24
-    }
-    val textDecoration = remember(isDone) {
-        if (isDone) TextDecoration.LineThrough
-        else TextDecoration.None
-    }
-
     AgendaListCard(
         modifier = modifier,
         backgroundColor = DarkGreen,
         contentColor = MaterialTheme.colors.onPrimary,
         description = description,
-        timestamp = timestamp,
+        formattedTime = timestamp,
         title = {
             Row(
                 modifier = Modifier.fillMaxWidth(0.9f),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { onToggleIsDone() }) {
+                IconButton(onClick = { setIsDone() }) {
                     Icon(
-                        painter = painterResource(id = iconResId),
+                        painter = painterResource(id = if (isDone) R.drawable.ic_outline_check_circle_24 else R.drawable.ic_outline_circle_24),
                         tint = MaterialTheme.colors.onPrimary,
                         contentDescription = stringResource(id = R.string.is_done_toggle_content_description),
                     )
@@ -70,7 +60,7 @@ fun TaskItem(
                 Text(
                     text = title,
                     style = MaterialTheme.typography.h2,
-                    textDecoration = textDecoration,
+                    textDecoration = if (isDone) TextDecoration.LineThrough else TextDecoration.None,
                 )
             }
         },

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
@@ -2,14 +2,17 @@ package com.gavinferiancek.tasky.agenda.presentation.list
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.agenda.domain.NavigationOptions
 import com.gavinferiancek.tasky.agenda.presentation.components.list.AgendaHeader
 import com.gavinferiancek.tasky.agenda.presentation.components.list.AgendaList
+import com.gavinferiancek.tasky.agenda.presentation.components.list.AgendaListFab
 import com.gavinferiancek.tasky.agenda.presentation.components.list.DaySelector
 import com.gavinferiancek.tasky.core.presentation.components.CardLayout
 import com.gavinferiancek.tasky.core.presentation.components.showSnackbar
@@ -21,45 +24,61 @@ import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 fun AgendaScreen(
     state: AgendaListState,
     events: (AgendaListEvents) -> Unit,
+    onLogout: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    onNavigateToEventDetail: (NavigationOptions) -> Unit,
+    onNavigateToTaskDetail: (NavigationOptions) -> Unit,
+    onNavigateToReminderDetail: (NavigationOptions) -> Unit,
 ) {
     val spacing = LocalSpacing.current
     val scaffoldState = rememberScaffoldState()
 
-    CardLayout(
-        header = {
-            AgendaHeader(
-                initialDate = state.initialDate,
-                onSelectDate = { date ->
-                    events(AgendaListEvents.UpdateInitialDate(date))
+    Scaffold(
+        scaffoldState = scaffoldState,
+        floatingActionButton = {
+            AgendaListFab(
+                onNavigateToEventDetail = onNavigateToEventDetail,
+                onNavigateToTaskDetail = onNavigateToTaskDetail,
+                onNavigateToReminderDetail = onNavigateToReminderDetail,
+            )
+        },
+    ) {
+        CardLayout(
+            header = {
+                AgendaHeader(
+                    initialDate = state.initialDate,
+                    onSelectDate = { date ->
+                        events(AgendaListEvents.UpdateInitialDate(date))
+                    },
+                )
+            }
+        ) {
+            DaySelector(
+                modifier = Modifier.fillMaxWidth(),
+                days = state.dayList,
+                selectedDay = state.selectedDay,
+                onSelectDay = { day ->
+                    events(AgendaListEvents.UpdateSelectedDay(day))
                 }
             )
-        }
-    ) {
-        DaySelector(
-            modifier = Modifier.fillMaxWidth(),
-            days = state.dayList,
-            selectedDay = state.selectedDay,
-            onSelectDay = { day ->
-                events(AgendaListEvents.UpdateSelectedDay(day))
-            }
-        )
-        Spacer(modifier = Modifier.height(spacing.large))
+            Spacer(modifier = Modifier.height(spacing.large))
 
-        Text(
-            text = state.listHeader.asString(),
-            color = MaterialTheme.colors.onSurface,
-            style = MaterialTheme.typography.h2,
-        )
-        Spacer(modifier = Modifier.height(spacing.medium))
-
-        SwipeRefresh(
-            state = rememberSwipeRefreshState(isRefreshing = state.isLoading),
-            onRefresh = { events(AgendaListEvents.OnRefresh) }
-        ) {
-            AgendaList(
-                pastItems = state.pastItems,
-                futureItems = state.futureItems,
+            Text(
+                text = state.listHeader.asString(),
+                color = MaterialTheme.colors.onSurface,
+                style = MaterialTheme.typography.h2,
             )
+            Spacer(modifier = Modifier.height(spacing.medium))
+
+            SwipeRefresh(
+                state = rememberSwipeRefreshState(isRefreshing = state.isLoading),
+                onRefresh = { events(AgendaListEvents.OnRefresh) }
+            ) {
+                AgendaList(
+                    pastItems = state.pastItems,
+                    futureItems = state.futureItems,
+                )
+            }
         }
     }
     showSnackbar(

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
@@ -80,8 +80,18 @@ fun AgendaScreen(
                 onRefresh = { events(AgendaListEvents.OnRefresh) }
             ) {
                 AgendaList(
+                    modifier = Modifier.fillMaxSize(),
                     pastItems = state.pastItems,
                     futureItems = state.futureItems,
+                    onToggleIsDone = { task ->
+                        events(AgendaListEvents.UpdateTask(task))
+                    },
+                    onNavigateToEventDetail = onNavigateToEventDetail,
+                    onNavigateToTaskDetail = onNavigateToTaskDetail,
+                    onNavigateToReminderDetail = onNavigateToReminderDetail,
+                    onDelete = { item ->
+                        events(AgendaListEvents.DeleteAgendaItem(item))
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
@@ -47,9 +47,14 @@ fun AgendaScreen(
             header = {
                 AgendaHeader(
                     initialDate = state.initialDate,
+                    name = state.name,
                     onSelectDate = { date ->
                         events(AgendaListEvents.UpdateInitialDate(date))
                     },
+                    onLogout = {
+                        onLogout()
+                        onNavigateToLogin()
+                    }
                 )
             }
         ) {

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListScreen.kt
@@ -1,6 +1,9 @@
 package com.gavinferiancek.tasky.agenda.presentation.list
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -83,7 +86,7 @@ fun AgendaScreen(
                     modifier = Modifier.fillMaxSize(),
                     pastItems = state.pastItems,
                     futureItems = state.futureItems,
-                    onToggleIsDone = { task ->
+                    setIsDone = { task ->
                         events(AgendaListEvents.UpdateTask(task))
                     },
                     onNavigateToEventDetail = onNavigateToEventDetail,

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListState.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListState.kt
@@ -1,6 +1,7 @@
 package com.gavinferiancek.tasky.agenda.presentation.list
 
 import com.gavinferiancek.tasky.R
+import com.gavinferiancek.tasky.agenda.domain.datetime.DateTimeManager
 import com.gavinferiancek.tasky.agenda.domain.model.AgendaItem
 import com.gavinferiancek.tasky.core.util.UiText
 import java.time.LocalDate
@@ -11,7 +12,7 @@ data class AgendaListState(
     val pastItems: List<AgendaItem> = listOf(),
     val futureItems: List<AgendaItem> = listOf(),
     val initialDate: LocalDate = LocalDate.now(),
-    val dayList: List<LocalDate> = listOf(),
+    val dayList: List<LocalDate> = DateTimeManager.generateDayList(initialDate),
     val listHeader: UiText = UiText.StringResource(id = R.string.date_today),
     val selectedDay: LocalDate = LocalDate.now(),
     val infoMessage: UiText? = null,

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListViewModel.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/agenda/presentation/list/AgendaListViewModel.kt
@@ -13,6 +13,8 @@ import com.gavinferiancek.tasky.agenda.domain.model.Reminder
 import com.gavinferiancek.tasky.agenda.domain.model.Task
 import com.gavinferiancek.tasky.agenda.domain.repository.AgendaRepository
 import com.gavinferiancek.tasky.core.data.remote.error.getUiText
+import com.gavinferiancek.tasky.core.domain.User
+import com.gavinferiancek.tasky.core.domain.getInitials
 import com.gavinferiancek.tasky.core.domain.preferences.UserPreferences
 import com.gavinferiancek.tasky.core.util.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,17 +31,10 @@ class AgendaListViewModel @Inject constructor(
     private val repository: AgendaRepository,
     userPreferences: UserPreferences,
 ) : ViewModel() {
-    var state by mutableStateOf(AgendaListState())
+    var state by mutableStateOf(AgendaListState(name = userPreferences.getUser().getInitials()))
         private set
 
-    init {
-        getAgenda(date = state.selectedDay)
-        state = state.copy(
-            dayList = dateManager.generateDayList(state.initialDate),
-            listHeader = generateListHeader(state.initialDate),
-            name = formatUserName(userPreferences.getName())
-        )
-    }
+    init { getAgenda(date = state.selectedDay) }
 
     fun onTriggerEvent(event: AgendaListEvents) {
         when (event) {
@@ -78,14 +73,6 @@ class AgendaListViewModel @Inject constructor(
                 val formatter = DateTimeFormatter.ofPattern("E d, u")
                 UiText.DynamicString(selectedDay.format(formatter))
             }
-        }
-    }
-
-    private fun formatUserName(fullName: String): String {
-        val splitName = fullName.split(" ")
-        return when (splitName.count()) {
-            1 -> splitName[0].substring(0, 2).uppercase()
-            else -> "${splitName[0][0]}${splitName[1][0]}".uppercase()
         }
     }
 

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/auth/data/repository/AuthRepositoryImpl.kt
@@ -19,14 +19,15 @@ class AuthRepositoryImpl(
         password: String,
     ): Result<Unit> {
         return try {
-            val authorizedUser = authApi.loginUser(
+            val user = authApi.loginUser(
                 loginRequest = LoginRequestDto(
                     email = email,
                     password = password,
                 )
             )
-            userPreferences.editToken(token = authorizedUser.token)
-            userPreferences.editName(name = authorizedUser.fullName)
+            userPreferences.editToken(token = user.token)
+            userPreferences.editName(name = user.fullName)
+            userPreferences.editId(id = user.userId)
             Result.success(Unit)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -78,8 +79,9 @@ class AuthRepositoryImpl(
         catch (e: HttpException) {
         } catch (e: IOException) {
         } finally {
-            userPreferences.editName("")
-            userPreferences.editToken("")
+            userPreferences.editName(name = "")
+            userPreferences.editToken(token ="")
+            userPreferences.editId(id = "")
         }
     }
 }

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/core/data/local/preferences/UserPreferencesImpl.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/core/data/local/preferences/UserPreferencesImpl.kt
@@ -3,6 +3,7 @@ package com.gavinferiancek.tasky.core.data.local.preferences
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.gavinferiancek.tasky.core.domain.User
 import com.gavinferiancek.tasky.core.domain.preferences.UserPreferences
 
 class UserPreferencesImpl(
@@ -20,10 +21,6 @@ class UserPreferencesImpl(
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
     )
 
-    override fun getToken(): String {
-        return userPreferences.getString("token", null)?: ""
-    }
-
     override fun editToken(token: String) {
         userPreferences
             .edit()
@@ -31,14 +28,25 @@ class UserPreferencesImpl(
             .apply()
     }
 
-    override fun getName(): String {
-        return userPreferences.getString("name", null)?: ""
-    }
-
     override fun editName(name: String) {
         userPreferences
             .edit()
             .putString("name", name)
             .apply()
+    }
+
+    override fun editId(id: String) {
+        userPreferences
+            .edit()
+            .putString("id", id)
+            .apply()
+    }
+
+    override fun getUser(): User {
+        return User(
+            token = userPreferences.getString("token", null)?: "",
+            name = userPreferences.getString("name", null)?: "",
+            id = userPreferences.getString("id", null)?: "",
+        )
     }
 }

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/core/data/remote/interceptor/AuthorizationInterceptor.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/core/data/remote/interceptor/AuthorizationInterceptor.kt
@@ -8,7 +8,7 @@ import okhttp3.Response
 class AuthorizationInterceptor(private val userPreferences: UserPreferences): Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val token = userPreferences.getToken()
+        val token = userPreferences.getUser().token
         val request = chain.request().newBuilder()
             .addHeader("x-api-key", BuildConfig.API_KEY)
             .addHeader("Authorization", "Bearer $token")

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/core/domain/User.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/core/domain/User.kt
@@ -1,0 +1,18 @@
+package com.gavinferiancek.tasky.core.domain
+
+data class User(
+    val token: String,
+    val name: String,
+    val id: String,
+)
+
+fun User.getInitials(): String {
+    // Initials are two characters long, so if <= just return name
+    if (name.length <= 2) return name.uppercase()
+
+    val splitName = name.uppercase().split(" ")
+    return when(splitName.count()) {
+        1 -> splitName[0].substring(0, 2)
+        else -> "${splitName.first()[0]}${splitName.last()[0]}"
+    }
+}

--- a/app/src/main/kotlin/com/gavinferiancek/tasky/core/domain/preferences/UserPreferences.kt
+++ b/app/src/main/kotlin/com/gavinferiancek/tasky/core/domain/preferences/UserPreferences.kt
@@ -1,13 +1,14 @@
 package com.gavinferiancek.tasky.core.domain.preferences
 
+import com.gavinferiancek.tasky.core.domain.User
 import kotlinx.coroutines.flow.Flow
 
 interface UserPreferences {
-    fun getToken(): String
-
     fun editToken(token: String)
 
-    fun getName(): String
-
     fun editName(name: String)
+
+    fun editId(id: String)
+
+    fun getUser(): User
 }


### PR DESCRIPTION
Bulk of this lies in creating the list items for each AgendaItem type.  These composables are somewhat nested and it might have introduced some extra code. 
- Wrapping the item types in the AgendaListItem is a little redundant, but that logic had to go somewhere. 
- Wrapping AgendaListCard with each Item type is also a little redundant, but it would be useful should item layouts start to vary or become more complex. (It would also be easy to change the AgendaListCard from taking in a description/timestamp and instead use a body/footer slot to support that kind of customization.)